### PR TITLE
tests: close lingering sockets in teardown and remove server listeners

### DIFF
--- a/tests/debug_llm_logging.test.js
+++ b/tests/debug_llm_logging.test.js
@@ -92,6 +92,17 @@ describe('llm payload logging when DEBUG_WEBHOOK=true', () => {
         }
       } catch {}
 
+      // Remove listeners to avoid bound anonymous functions remaining
+      try {
+        if (server && typeof server.removeAllListeners === 'function') {
+          try {
+            server.removeAllListeners('connection');
+            server.removeAllListeners('request');
+            server.removeAllListeners('listening');
+          } catch {}
+        }
+      } catch {}
+
       if (server && typeof server.close === 'function') {
         await new Promise((resolve) => server.close(resolve));
       }

--- a/tests/globalTeardown.js
+++ b/tests/globalTeardown.js
@@ -311,6 +311,27 @@ module.exports = async () => {
     // ignore
   }
 
+  // Short grace period: allow OS to fully close sockets and for any
+  // asynchronous cleanup to complete before Jest's final open-handle
+  // detection runs. Then attempt one more best-effort cleanup pass.
+  try {
+    await new Promise((r) => setTimeout(r, 150));
+  } catch {}
+  try {
+    try {
+      const rh2 = require('./helpers/request-helper');
+      if (rh2 && typeof rh2._forceCloseTemporaryServers === 'function') {
+        appendLog('globalTeardown: final force-closing temporary servers');
+        try {
+          await rh2._forceCloseTemporaryServers();
+          appendLog('globalTeardown: final temporary servers closed');
+        } catch (e) {
+          appendLog(`globalTeardown: final _forceCloseTemporaryServers error: ${e && e.message}`);
+        }
+      }
+    } catch {}
+  } catch {}
+
   // Append final marker
   try {
     // Log active handles count and types for CI debugging


### PR DESCRIPTION
Summary:\n- Add brief grace wait in 	ests/globalTeardown.js and final call to equest-helper's _forceCloseTemporaryServers() to allow socket cleanup.\n- Remove server listeners in 	ests/debug_llm_logging.test.js before server.close() to avoid bound-anonymous-fn handles reported by Jest.\n\nVerification: ran 
pm test locally; all suites passed and Jest no longer reported open-handle warnings.\n